### PR TITLE
Fixed benchmark problems 10, 11, 48

### DIFF
--- a/drivers/cpp/benchmarks/geometry/10_geometry_convex_hull/baseline.hpp
+++ b/drivers/cpp/benchmarks/geometry/10_geometry_convex_hull/baseline.hpp
@@ -29,6 +29,8 @@ void NO_INLINE correctConvexHull(std::vector<Point> const& points, std::vector<P
     std::vector<Point> lowerHull;
     upperHull.push_back(pointsSorted[0]);
     upperHull.push_back(pointsSorted[1]);
+    lowerHull.push_back(pointsSorted[pointsSorted.size() - 1]);
+    lowerHull.push_back(pointsSorted[pointsSorted.size() - 2]);
 
     for (size_t i = 2; i < pointsSorted.size(); i++) {
         while (upperHull.size() > 1
@@ -47,7 +49,7 @@ void NO_INLINE correctConvexHull(std::vector<Point> const& points, std::vector<P
         }
         lowerHull.push_back(pointsSorted[pointsSorted.size() - i - 1]);
     }
-    upperHull.insert(upperHull.end(), lowerHull.begin(), lowerHull.end());
+    upperHull.insert(upperHull.end(), lowerHull.begin()+1, lowerHull.end()-1);
 
     hull = upperHull;
     return;

--- a/drivers/cpp/benchmarks/geometry/11_geometry_convex_hull_perimeter/baseline.hpp
+++ b/drivers/cpp/benchmarks/geometry/11_geometry_convex_hull_perimeter/baseline.hpp
@@ -34,6 +34,8 @@ double NO_INLINE correctConvexHullPerimeter(std::vector<Point> const& points) {
     std::vector<Point> lowerHull;
     upperHull.push_back(pointsSorted[0]);
     upperHull.push_back(pointsSorted[1]);
+    lowerHull.push_back(pointsSorted[pointsSorted.size() - 1]);
+    lowerHull.push_back(pointsSorted[pointsSorted.size() - 2]);
 
     for (size_t i = 2; i < pointsSorted.size(); i++) {
         while (upperHull.size() > 1
@@ -52,7 +54,7 @@ double NO_INLINE correctConvexHullPerimeter(std::vector<Point> const& points) {
         }
         lowerHull.push_back(pointsSorted[pointsSorted.size() - i - 1]);
     }
-    upperHull.insert(upperHull.end(), lowerHull.begin(), lowerHull.end());
+    upperHull.insert(upperHull.end(), lowerHull.begin()+1, lowerHull.end()-1);
 
     double perimeter = 0;
     for (size_t i = 0; i < upperHull.size() - 1; i++) {

--- a/drivers/cpp/benchmarks/sparse_la/48_sparse_la_sparse_axpy/cpu.cc
+++ b/drivers/cpp/benchmarks/sparse_la/48_sparse_la_sparse_axpy/cpu.cc
@@ -122,7 +122,6 @@ bool validate(Context *ctx) {
         correctSparseAxpy(alpha, x, y, correct);
 
         // compute test result
-        test.clear();
         sparseAxpy(alpha, x, y, test);
         SYNC();
         


### PR DESCRIPTION
Summary of the changes:

- Problem 10 and 11: Fixed how the convex hull is computed -- now lower hull computations are correct and the endpoints for the lower hull is not included (since they are also endpoints for the upper hull). Should Fix #37 but I have not tested it extensively.
- Problem 48: Should not clear the test vector after initialized it with a number of 0's.